### PR TITLE
Add test scripts on cori / perlmutter and fix _find_mpi_process bug

### DIFF
--- a/tests/_common_utils.py
+++ b/tests/_common_utils.py
@@ -21,3 +21,17 @@ def skip_probe(min_cores=8):
                 f"Skipping test with ncores < {min_cores}", allow_module_level=False
             )
 
+def skip_slurm():
+    """Test if single step needs to be skipped"""
+    with VaspInteractive() as test_calc:
+        args = test_calc.make_command().split()
+        do_test = True
+        for i, param in enumerate(args):
+            if "srun" in param:
+                do_test = False
+                break
+        if do_test is False:
+            pytest.skip(
+                f"Skipping test started by srun", allow_module_level=False
+            )
+

--- a/tests/job_test_cori_hsw.sh
+++ b/tests/job_test_cori_hsw.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -l
+#SBATCH -N 1
+#SBATCH -C haswell
+#SBATCH -q premium
+#SBATCH -A m2755
+#SBATCH -t 06:00:00
+
+root="/global/u1/t/ttian20/vasp-interactive-test"
+export VASP_COMMAND="srun -n 32 -c 2 --cpu-bind=cores vasp_std"
+# vpi is the conda environment prebuilt
+conda activate vpi
+pip install -e $root
+for ver in "vasp/5.4.4-hsw" "vasp/6.3.0-hsw"
+do
+    module load $ver
+    echo "Testing VaspInteractive on $ver"
+    for f in $root/tests/test*.py
+    do
+        pytest -svv $f; killall vasp_std || echo ""
+    done
+    module unload vasp
+done

--- a/tests/job_test_cori_knl.sh
+++ b/tests/job_test_cori_knl.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -l
+#SBATCH -N 1
+#SBATCH -C knl
+#SBATCH -q premium
+#SBATCH -A m2755
+#SBATCH -t 06:00:00
+
+root="/global/u1/t/ttian20/vasp-interactive-test"
+export VASP_COMMAND="srun -n 64 -c 4 --cpu-bind=cores vasp_std"
+# vpi is the conda environment prebuilt
+conda activate vpi
+pip install -e $root
+for ver in "vasp/5.4.4-knl" "vasp/6.3.0-knl"
+do
+    module load $ver
+    echo "Testing VaspInteractive on $ver"
+    for f in $root/tests/test*.py
+    do
+        pytest -svv $f; killall vasp_std || echo ""
+    done
+    module unload vasp
+done

--- a/tests/job_test_perlmutter_cpu.sh
+++ b/tests/job_test_perlmutter_cpu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+#SBATCH -N 1
+#SBATCH -C cpu
+#SBATCH -q premium
+#SBATCH -A m2755
+#SBATCH -t 06:00:00
+
+
+
+root="/global/u1/t/ttian20/vasp-interactive-test"
+export OMP_NUM_THREADS=1
+export VASP_COMMAND="srun -n 8 -c 32 --cpu-bind=cores vasp_std"
+# vpi is the conda environment prebuilt
+module load python
+conda activate vpi
+pip install -e $root
+for ver in  "vasp/5.4.4-cpu" "vasp/6.3.2-cpu"
+do
+    module load $ver
+    echo "Testing VaspInteractive on $ver"
+    for f in $root/tests/test*.py
+    do
+        pytest -svv $f; killall vasp_std || echo ""
+    done
+    module unload vasp
+done

--- a/tests/test_mpi_pause.py
+++ b/tests/test_mpi_pause.py
@@ -11,7 +11,7 @@ import os
 from ase.atoms import Atoms
 from ase.optimize import BFGS
 from copy import copy, deepcopy
-from _common_utils import skip_probe
+from _common_utils import skip_probe, skip_slurm
 
 
 d = 0.9575
@@ -32,6 +32,7 @@ def get_average_cpu(pid, interval=0.5):
 def test_pause_cpu_percent():
     """Send pause signal to mpi process and see if drops below threshold"""
     skip_probe(4)
+    skip_slurm()
     h2 = h2_root.copy()
     threshold_high = 75.0
     threshold_low = 25.0
@@ -55,6 +56,7 @@ def test_pause_cpu_percent():
 def test_pause_context():
     """Context mode"""
     skip_probe(4)
+    skip_slurm()
     h2 = h2_root.copy()
     threshold_high = 75.0
     threshold_low = 25.0

--- a/tests/test_prop_au.py
+++ b/tests/test_prop_au.py
@@ -72,7 +72,8 @@ def run_vasp_interactive():
 
 
 def test_main():
-    skip_probe(8)
+    # This test is extremely expensive and does not need to perform in most cases.
+    skip_probe(128)
     ec, fc = run_vasp_classic()
     ei, fi = run_vasp_interactive()
     print(ec, fc)


### PR DESCRIPTION
Related to #25

Currently all tests on cori cpu (excluding mpi pause tests) pass while perlmutter's cpu vasp fails to render output. 